### PR TITLE
Retire London's meetup on the front page.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -29,7 +29,7 @@
             {% endif %}
 
             <li class="social-item">
-                {% include icon-meetup-grey.html url="http://www.meetup.com/it-IT/HumanOps-London/" text="meetup" %}
+                {% include icon-meetup-grey.html url="http://www.meetup.com/HumanOps-London/" text="meetup" %}
             </li>
 
         {% endcomment %}

--- a/_sections/4-what-can-we-do.html
+++ b/_sections/4-what-can-we-do.html
@@ -21,7 +21,7 @@ align: section--center
             {% include icon-meetup.svg %}
             <h3>London</h3>
             <p class="item-text">
-                {% include icon-calendar.svg %} Mon Nov 21, 2016
+                {% include icon-calendar.svg %} <del>Mon Nov 21, 2016</del>
                 <br />
                 {% include icon-location.svg %} Facebook HQ
             </p>


### PR DESCRIPTION
This commit updates the front page making sure that the date for the London's
meetup is now crossed over, plus a tiny fix to the URL.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>